### PR TITLE
Update home.dart

### DIFF
--- a/home.dart
+++ b/home.dart
@@ -27,7 +27,7 @@ class _HomeState extends State<Home> {
         },
       ),
     );
-    if (result.isNotEmpty || result != null) {
+    if (result?.isNotEmpty ?? false) {
       
       setState(() {
         selectedAssetList.addAll(result);


### PR DESCRIPTION
When going back without selecting an item, `result` can be `null`, which lead to this exception:
```E/flutter ( 5835): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: NoSuchMethodError: The getter 'isNotEmpty' was called on null.
```